### PR TITLE
feat: support deparse exclusion exclude element and operator via CGO

### DIFF
--- a/parser/include/pg_query.h
+++ b/parser/include/pg_query.h
@@ -95,6 +95,7 @@ PgQueryDeparseResult pg_query_deparse_protobuf(PgQueryProtobuf parse_tree);
 
 enum DeparseType{
 	deparse_type_expr,
+  deparse_type_exclusions,
 };
 PgQueryDeparseResult pg_query_deparse_node_protobuf(enum DeparseType deparse_type, PgQueryProtobuf parse_tree);
 

--- a/parser/pg_query_deparse.c
+++ b/parser/pg_query_deparse.c
@@ -207,6 +207,7 @@ static void deparseStmt(StringInfo str, Node *node);
 static void deparseValue(StringInfo str, Value *value, DeparseNodeContext context);
 
 static PgQueryDeparseResult pg_query_deparse_expr_protobuf(PgQueryProtobuf parse_tree);
+static PgQueryDeparseResult pg_query_deparse_exclusion_protobuf(PgQueryProtobuf parse_tree);
 
 // "any_name" in gram.y
 static void deparseAnyName(StringInfo str, List *parts)
@@ -9914,9 +9915,65 @@ PgQueryDeparseResult pg_query_deparse_node_protobuf(enum DeparseType deparse_typ
 		case deparse_type_expr:
 			return pg_query_deparse_expr_protobuf(parse_tree);
 			break;
+		case deparse_type_exclusions:
+			return pg_query_deparse_exclusion_protobuf(parse_tree);
 		default:
 			elog(ERROR, "deparse node: unsupported deparse type: %d", deparse_type);
 	}
+}
+
+PgQueryDeparseResult pg_query_deparse_exclusion_protobuf(PgQueryProtobuf parse_tree)
+{
+	PgQueryDeparseResult result = {0};
+	StringInfoData str;
+	MemoryContext ctx;
+	List *stmts;
+	ListCell *lc;
+
+	ctx = pg_query_enter_memory_context();
+
+	PG_TRY();
+	{
+		stmts = pg_query_protobuf_to_nodes(parse_tree);
+		
+		initStringInfo(&str);
+
+		foreach(lc, stmts){
+			RawStmt *stmt = castNode(RawStmt, lfirst(lc));
+			List *exclusion = castNode(List, stmt->stmt);
+				deparseIndexElem(&str, castNode(IndexElem, linitial(exclusion)));
+				appendStringInfoString(&str, " WITH ");
+				deparseAnyOperator(&str, castNode(List, lsecond(exclusion)));
+				if (lnext(stmts, lc))
+					appendStringInfoString(&str, ", ");
+		}
+		result.query = strdup(str.data);
+	}
+	PG_CATCH();
+	{
+		ErrorData* error_data;
+		PgQueryError* error;
+
+		MemoryContextSwitchTo(ctx);
+		error_data = CopyErrorData();
+
+		// Note: This is intentionally malloc so exiting the memory context doesn't free this
+		error = malloc(sizeof(PgQueryError));
+		error->message   = strdup(error_data->message);
+		error->filename  = strdup(error_data->filename);
+		error->funcname  = strdup(error_data->funcname);
+		error->context   = NULL;
+		error->lineno	= error_data->lineno;
+		error->cursorpos = error_data->cursorpos;
+
+		result.error = error;
+		FlushErrorState();
+	}
+	PG_END_TRY();
+
+	pg_query_exit_memory_context(ctx);
+
+	return result;
 }
 
 PgQueryDeparseResult pg_query_deparse_expr_protobuf(PgQueryProtobuf parse_tree)

--- a/pg_query.go
+++ b/pg_query.go
@@ -11,7 +11,8 @@ import (
 type DeparseType int
 
 const (
-	DeparseTypeExpr DeparseType = iota
+	DeparseTypeExpr      DeparseType = iota
+	DeparseTypeExclusion DeparseType = iota
 )
 
 func DeparseNode(tp DeparseType, node *Node) (output string, err error) {
@@ -34,6 +35,24 @@ func DeparseNode(tp DeparseType, node *Node) (output string, err error) {
 	}
 }
 
+func DeparseNodes(tp DeparseType, nodes []*Node) (output string, err error) {
+	switch tp {
+	case DeparseTypeExclusion:
+		tree := &ParseResult{}
+		for _, node := range nodes {
+			tree.Stmts = append(tree.Stmts, &RawStmt{
+				Stmt: node,
+			})
+		}
+		protobufTree, err := proto.Marshal(tree)
+		if err != nil {
+			return "", err
+		}
+		return parser.DeparseNodeFromProtobuf(int(tp), protobufTree)
+	default:
+		return "", fmt.Errorf("deparse node failed: unsupported deparse type %d", tp)
+	}
+}
 func Scan(input string) (result *ScanResult, err error) {
 	protobufScan, err := parser.ScanToProtobuf(input)
 	if err != nil {


### PR DESCRIPTION
This PR make Bytebase PostgreSQL Schema Diff be able to use pg_query_go to deparse the exclude element and operator in exclude constraint.
Completing BYT-1763.